### PR TITLE
Migrate to Dagger Hilt version 2.31.2-alpha

### DIFF
--- a/app/src/main/java/com/paulrybitskyi/docskanner/di/CoreModule.kt
+++ b/app/src/main/java/com/paulrybitskyi/docskanner/di/CoreModule.kt
@@ -21,10 +21,10 @@ import com.paulrybitskyi.docskanner.utils.dialogs.DialogBuilderImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 internal interface CoreModule {
 
     @Binds

--- a/app/src/main/java/com/paulrybitskyi/docskanner/ui/dashboard/fragment/DashboardViewModel.kt
+++ b/app/src/main/java/com/paulrybitskyi/docskanner/ui/dashboard/fragment/DashboardViewModel.kt
@@ -19,7 +19,6 @@ package com.paulrybitskyi.docskanner.ui.dashboard.fragment
 import android.Manifest.permission.CAMERA
 import android.net.Uri
 import androidx.core.net.toUri
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
@@ -42,12 +41,15 @@ import com.paulrybitskyi.docskanner.ui.views.docs.DocsUiState
 import com.paulrybitskyi.docskanner.utils.dialogs.DialogConfig
 import com.paulrybitskyi.docskanner.utils.dialogs.DialogContent
 import com.paulrybitskyi.docskanner.utils.dialogs.DialogItem
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.io.File
+import javax.inject.Inject
 
 
-internal class DashboardViewModel @ViewModelInject constructor(
+@HiltViewModel
+internal class DashboardViewModel @Inject constructor(
     private val observeAppStorageFolderFilesUseCase: ObserveAppStorageFolderFilesUseCase,
     private val copyFileUseCase: CopyFileUseCase,
     private val docsUiStateFactory: DocsUiStateFactory,

--- a/app/src/main/java/com/paulrybitskyi/docskanner/ui/editor/DocEditorViewModel.kt
+++ b/app/src/main/java/com/paulrybitskyi/docskanner/ui/editor/DocEditorViewModel.kt
@@ -18,7 +18,6 @@ package com.paulrybitskyi.docskanner.ui.editor
 
 import android.graphics.Bitmap
 import androidx.hilt.Assisted
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.*
 import com.paulrybitskyi.docskanner.R
 import com.paulrybitskyi.docskanner.core.factories.PdfDocumentFileNameFactory
@@ -35,6 +34,7 @@ import com.paulrybitskyi.docskanner.ui.base.BaseViewModel
 import com.paulrybitskyi.docskanner.ui.base.events.commons.GeneralCommand
 import com.paulrybitskyi.docskanner.utils.dialogs.DialogConfig
 import com.paulrybitskyi.docskanner.utils.dialogs.DialogContent
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
@@ -42,12 +42,14 @@ import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import java.io.File
+import javax.inject.Inject
 
 
 private const val PARAM_DOC_IMAGE_FILE = "doc_image_file"
 
 
-internal class DocEditorViewModel @ViewModelInject constructor(
+@HiltViewModel
+internal class DocEditorViewModel @Inject constructor(
     private val convertImageToPdfUseCase: ConvertImageToPdfUseCase,
     private val clearAppCacheUseCase: ClearAppCacheUseCase,
     private val pdfDocumentFileNameFactory: PdfDocumentFileNameFactory,

--- a/app/src/main/java/com/paulrybitskyi/docskanner/ui/preview/DocPreviewViewModel.kt
+++ b/app/src/main/java/com/paulrybitskyi/docskanner/ui/preview/DocPreviewViewModel.kt
@@ -17,22 +17,24 @@
 package com.paulrybitskyi.docskanner.ui.preview
 
 import androidx.hilt.Assisted
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.paulrybitskyi.docskanner.ui.Constants
 import com.paulrybitskyi.docskanner.ui.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.io.File
+import javax.inject.Inject
 
 
 private const val PARAM_DOC_FILE = "doc_file"
 
 
-internal class DocPreviewViewModel @ViewModelInject constructor(
+@HiltViewModel
+internal class DocPreviewViewModel @Inject constructor(
     @Assisted private val savedStateHandle: SavedStateHandle
 ) : BaseViewModel() {
 

--- a/app/src/main/java/com/paulrybitskyi/docskanner/ui/scanner/DocScannerViewModel.kt
+++ b/app/src/main/java/com/paulrybitskyi/docskanner/ui/scanner/DocScannerViewModel.kt
@@ -18,7 +18,6 @@ package com.paulrybitskyi.docskanner.ui.scanner
 
 import android.graphics.Bitmap
 import androidx.hilt.Assisted
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.liveData
@@ -32,16 +31,19 @@ import com.paulrybitskyi.docskanner.domain.SaveImageToFileUseCase
 import com.paulrybitskyi.docskanner.ui.Constants
 import com.paulrybitskyi.docskanner.ui.base.BaseViewModel
 import com.paulrybitskyi.docskanner.ui.base.events.commons.GeneralCommand
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import java.io.File
+import javax.inject.Inject
 
 
 private const val PARAM_DOC_IMAGE_FILE = "doc_image_file"
 
 
-internal class DocScannerViewModel @ViewModelInject constructor(
+@HiltViewModel
+internal class DocScannerViewModel @Inject constructor(
     private val saveImageToFileUseCase: SaveImageToFileUseCase,
     private val temporaryImageFileFactory: TemporaryImageFileFactory,
     private val stringProvider: StringProvider,

--- a/app/src/main/java/com/paulrybitskyi/docskanner/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/paulrybitskyi/docskanner/ui/splash/SplashViewModel.kt
@@ -17,7 +17,6 @@
 package com.paulrybitskyi.docskanner.ui.splash
 
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.viewModelScope
 import com.paulrybitskyi.docskanner.R
 import com.paulrybitskyi.docskanner.core.providers.StringProvider
@@ -32,12 +31,15 @@ import com.paulrybitskyi.docskanner.ui.base.BaseViewModel
 import com.paulrybitskyi.docskanner.ui.base.events.commons.GeneralCommand
 import com.paulrybitskyi.docskanner.utils.dialogs.DialogConfig
 import com.paulrybitskyi.docskanner.utils.dialogs.DialogContent
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-internal class SplashViewModel @ViewModelInject constructor(
+@HiltViewModel
+internal class SplashViewModel @Inject constructor(
     private val imageProcessorInitializer: ImageProcessorInitializer,
     private val createAppStorageFolderUseCase: CreateAppStorageFolderUseCase,
     private val clearAppCacheUseCase: ClearAppCacheUseCase,

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -39,7 +39,7 @@ object versions {
 
     const val kotlin = "1.4.21" // also in buildSrc build.gradle.kts file
     const val navigationVersion = "2.3.2"
-    const val daggerHilt = "2.28.3-alpha"
+    const val daggerHilt = "2.31.2-alpha"
     const val gradleVersionsPlugin = "0.36.0"
 
 }

--- a/core/src/androidTest/java/com/paulrybitskyi/docskanner/core/ExampleInstrumentedTest.kt
+++ b/core/src/androidTest/java/com/paulrybitskyi/docskanner/core/ExampleInstrumentedTest.kt
@@ -18,7 +18,7 @@ package com.paulrybitskyi.docskanner.core
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/core/src/main/java/com/paulrybitskyi/docskanner/core/di/CoreModule.kt
+++ b/core/src/main/java/com/paulrybitskyi/docskanner/core/di/CoreModule.kt
@@ -21,10 +21,10 @@ import com.paulrybitskyi.docskanner.core.DocDetailsBuilderImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 internal interface CoreModule {
 
     @Binds

--- a/core/src/main/java/com/paulrybitskyi/docskanner/core/di/FactoriesModule.kt
+++ b/core/src/main/java/com/paulrybitskyi/docskanner/core/di/FactoriesModule.kt
@@ -20,10 +20,10 @@ import com.paulrybitskyi.docskanner.core.factories.*
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 internal interface FactoriesModule {
 
     @Binds

--- a/core/src/main/java/com/paulrybitskyi/docskanner/core/di/FormattersModule.kt
+++ b/core/src/main/java/com/paulrybitskyi/docskanner/core/di/FormattersModule.kt
@@ -23,10 +23,10 @@ import com.paulrybitskyi.docskanner.core.formatters.DocSizeFormatterImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 internal interface FormattersModule {
 
     @Binds

--- a/core/src/main/java/com/paulrybitskyi/docskanner/core/di/ProvidersModule.kt
+++ b/core/src/main/java/com/paulrybitskyi/docskanner/core/di/ProvidersModule.kt
@@ -20,10 +20,10 @@ import com.paulrybitskyi.docskanner.core.providers.*
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 internal interface ProvidersModule {
 
     @Binds

--- a/core/src/main/java/com/paulrybitskyi/docskanner/core/di/VerifiersModule.kt
+++ b/core/src/main/java/com/paulrybitskyi/docskanner/core/di/VerifiersModule.kt
@@ -20,10 +20,10 @@ import com.paulrybitskyi.docskanner.core.verifiers.*
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 internal interface VerifiersModule {
 
     @Binds

--- a/core/src/test/java/com/paulrybitskyi/docskanner/core/ExampleUnitTest.kt
+++ b/core/src/test/java/com/paulrybitskyi/docskanner/core/ExampleUnitTest.kt
@@ -16,7 +16,7 @@
 
 package com.paulrybitskyi.docskanner.core
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**

--- a/data/src/androidTest/java/com/paulrybitskyi/docskanner/data/ExampleInstrumentedTest.kt
+++ b/data/src/androidTest/java/com/paulrybitskyi/docskanner/data/ExampleInstrumentedTest.kt
@@ -18,7 +18,7 @@ package com.paulrybitskyi.docskanner.data
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/data/src/main/java/com/paulrybitskyi/docskanner/data/di/UseCasesModule.kt
+++ b/data/src/main/java/com/paulrybitskyi/docskanner/data/di/UseCasesModule.kt
@@ -21,10 +21,10 @@ import com.paulrybitskyi.docskanner.domain.*
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 internal interface UseCasesModule {
 
 

--- a/data/src/test/java/com/paulrybitskyi/docskanner/data/ExampleUnitTest.kt
+++ b/data/src/test/java/com/paulrybitskyi/docskanner/data/ExampleUnitTest.kt
@@ -16,7 +16,7 @@
 
 package com.paulrybitskyi.docskanner.data
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**

--- a/domain/src/androidTest/java/com/paulrybitskyi/docskanner/domain/ExampleInstrumentedTest.kt
+++ b/domain/src/androidTest/java/com/paulrybitskyi/docskanner/domain/ExampleInstrumentedTest.kt
@@ -18,7 +18,7 @@ package com.paulrybitskyi.docskanner.domain
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/domain/src/test/java/com/paulrybitskyi/docskanner/domain/ExampleUnitTest.kt
+++ b/domain/src/test/java/com/paulrybitskyi/docskanner/domain/ExampleUnitTest.kt
@@ -16,7 +16,7 @@
 
 package com.paulrybitskyi.docskanner.domain
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**

--- a/image-loading/src/main/java/com/paulrybitskyi/docskanner/imageloading/di/ImageLoadingBindingsModule.kt
+++ b/image-loading/src/main/java/com/paulrybitskyi/docskanner/imageloading/di/ImageLoadingBindingsModule.kt
@@ -21,10 +21,10 @@ import com.paulrybitskyi.docskanner.imageloading.ImageLoaderImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 internal interface ImageLoadingBindingsModule {
 
     @Binds

--- a/image-loading/src/main/java/com/paulrybitskyi/docskanner/imageloading/di/ImageLoadingModule.kt
+++ b/image-loading/src/main/java/com/paulrybitskyi/docskanner/imageloading/di/ImageLoadingModule.kt
@@ -25,12 +25,12 @@ import com.squareup.picasso.Picasso
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 internal object ImageLoadingModule {
 
 

--- a/image-processing/src/main/java/com/paulrybitskyi/docskanner/imageprocessing/di/ImageProcessingModule.kt
+++ b/image-processing/src/main/java/com/paulrybitskyi/docskanner/imageprocessing/di/ImageProcessingModule.kt
@@ -33,10 +33,10 @@ import com.paulrybitskyi.docskanner.imageprocessing.resize.ResizeTransformationF
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 internal interface ImageProcessingModule {
 
 


### PR DESCRIPTION
Migrate to a new version of the Dagger Hilt library called 2.31.2-alpha.