### PR TITLE
Use JDK 1.8 in the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
       - name: Test Application
         run: ./gradlew check
 


### PR DESCRIPTION
Use JDK 1.8 in the build workflow.