### PR TITLE
Split APK into multiple ones

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,15 @@ android {
         }
     }
 
+    splits {
+        abi {
+            isEnable = true
+            reset()
+            include("x86", "x86_64", "armeabi-v7a", "arm64-v8a")
+            isUniversalApk = false
+        }
+    }
+
     buildFeatures {
         viewBinding = true
     }


### PR DESCRIPTION
Split the APK into multiple ones based on their ABIs (Application Binary Interfaces) to decrease the size.