### PR TITLE
Improve GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   check:
     runs-on: [ubuntu-latest]
+    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
 
     steps:
       - name: Checkout Repo
@@ -31,13 +32,17 @@ jobs:
           path: |
             ~/.gradle/caches/
             ~/.gradle/wrapper/
-          key: ${{ runner.os }}-gradle-${{ hashFiles('checksum.txt') }}
+          key: cache-gradle-${{ runner.os }}-${{ hashFiles('checksum.txt') }}
+          restore-keys: |
+            cache-gradle-${{ runner.os }}-
+            cache-gradle-
 
       - name: Test Application
         run: ./gradlew check
 
   assemble:
     runs-on: [ubuntu-latest]
+    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
 
     steps:
       - name: Checkout Repo
@@ -60,7 +65,10 @@ jobs:
           path: |
             ~/.gradle/caches/
             ~/.gradle/wrapper/
-          key: ${{ runner.os }}-gradle-${{ hashFiles('checksum.txt') }}
+          key: cache-gradle-${{ runner.os }}-${{ hashFiles('checksum.txt') }}
+          restore-keys: |
+            cache-gradle-${{ runner.os }}-
+            cache-gradle-
 
       - name: Build Debug APK
         run: ./gradlew assembleDebug

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -2,16 +2,14 @@ name: Validate Gradle Wrapper
 
 on:
   push:
-    branches:
-      - '*'
+    branches: [ master ]
   pull_request:
-    branches:
-      - '*'
+    branches: [ master ]
 
 jobs:
   validation:
-    name: Validation
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,10 @@ jobs:
           path: |
             ~/.gradle/caches/
             ~/.gradle/wrapper/
-          key: ${{ runner.os }}-gradle-${{ hashFiles('checksum.txt') }}
+          key: cache-gradle-${{ runner.os }}-${{ hashFiles('checksum.txt') }}
+          restore-keys: |
+            cache-gradle-${{ runner.os }}-
+            cache-gradle-
 
       - name: Build Debug APK
         run: ./gradlew assembleDebug


### PR DESCRIPTION
Improve GitHub workflows by doing the following:

- Configure better Gradle folders caching strategy
- Add the option to skip running CI jobs